### PR TITLE
Allowed "Relate Selected Items" for Notes

### DIFF
--- a/chrome/content/zutilo/zoteroOverlay.js
+++ b/chrome/content/zutilo/zoteroOverlay.js
@@ -270,9 +270,9 @@ ZutiloChrome.zoteroOverlay = {
 	},
     
 	relateItems: function() {
-		var zitems = this.getSelectedItems('regular');
+		var zitems = this.getSelectedItems(['regular','note']);
 		
-		if (!this.checkItemNumber(zitems,'regular2')) {
+		if (!this.checkItemNumber(zitems,'regularOrNote1')) {
 			return false;
 		}
 		


### PR DESCRIPTION
Similar to recent change allowing copying and pasting of tags for notes, this update extends the Relate helper function to accommodate Notes.
