### PR TITLE
Add "Zutilo Preferences" to menu "Tools"

### DIFF
--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -707,6 +707,7 @@ ZutiloChrome.zoteroOverlay = {
 
     overlayZoteroPane: function(doc) {
         ZutiloChrome.zoteroOverlay.zoteroActionsMenu(doc);
+		ZutiloChrome.zoteroOverlay.zoteroMenu(doc);
         ZutiloChrome.zoteroOverlay.zoteroItemPopup(doc);
     },
 
@@ -742,6 +743,32 @@ ZutiloChrome.zoteroOverlay = {
         ZutiloChrome.registerXUL(zutiloMenuItemID, doc);
     },
 
+	zoteroMenu: function(doc) {
+        // Add Zutilo preferences item to Zotero actions menu
+        var zoteroToolsMenu = doc.getElementById('menu_ToolsPopup');
+        if (zoteroToolsMenu === null) {
+            // Don't do anything if elements not loaded yet
+            return;
+        }
+
+        var zutiloMenuItem = doc.createElement('menuitem');
+        var zutiloMenuItemID = 'zutilo-zotero-actions-preferences';
+        zutiloMenuItem.setAttribute('id', zutiloMenuItemID);
+        zutiloMenuItem.setAttribute('label',
+            Zutilo._bundle.
+                GetStringFromName('zutilo.zotero.actions.preferences'));
+        zutiloMenuItem.addEventListener('command',
+            function() {
+                ZutiloChrome.openPreferences();
+            }, false);
+        var zoteroPrefsItem =
+            doc.getElementById('menu_preferences');
+        zoteroToolsMenu.insertBefore(zutiloMenuItem,
+                                      zoteroPrefsItem.nextSibling);
+
+        ZutiloChrome.registerXUL(zutiloMenuItemID, doc);
+    },
+	
     /******************************************/
     // Item menu functions
     /******************************************/


### PR DESCRIPTION
Because, in Zotero 5.0, "the Actions (gear icon) menu has been removed from
the toolbar, as all options are now available in menus.
(I've not removed the "Zutilo Prefs" which still appears in the Actions menu in 4.0.)