### PR TITLE
Add "Zutilo Preferences" to menu

### DIFF
--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -707,6 +707,7 @@ ZutiloChrome.zoteroOverlay = {
 
     overlayZoteroPane: function(doc) {
         ZutiloChrome.zoteroOverlay.zoteroActionsMenu(doc);
+        ZutiloChrome.zoteroOverlay.zoteroMenu(doc);
         ZutiloChrome.zoteroOverlay.zoteroItemPopup(doc);
     },
 
@@ -741,7 +742,33 @@ ZutiloChrome.zoteroOverlay = {
 
         ZutiloChrome.registerXUL(zutiloMenuItemID, doc);
     },
+	
+	zoteroMenu: function(doc) {
+        // Add Zutilo preferences item to Zotero actions menu
+		var zoteroPrefsMenu = doc.getElementById('menu_preferences').parentElement;
+        if (zoteroPrefsMenu === null) {
+            // Don't do anything if elements not loaded yet
+            return;
+        }
 
+        var zutiloMenuItem = doc.createElement('menuitem');
+        var zutiloMenuItemID = 'zutilo-zotero-actions-preferences';
+        zutiloMenuItem.setAttribute('id', zutiloMenuItemID);
+        zutiloMenuItem.setAttribute('label',
+            Zutilo._bundle.
+                GetStringFromName('zutilo.zotero.actions.preferences'));
+        zutiloMenuItem.addEventListener('command',
+            function() {
+                ZutiloChrome.openPreferences();
+            }, false);
+        var zoteroPrefsItem =
+            doc.getElementById('menu_preferences');
+        zoteroPrefsMenu.insertBefore(zutiloMenuItem,
+                                      zoteroPrefsItem.nextSibling);
+
+        ZutiloChrome.registerXUL(zutiloMenuItemID, doc);
+    },
+	
     /******************************************/
     // Item menu functions
     /******************************************/

--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -706,9 +706,14 @@ ZutiloChrome.zoteroOverlay = {
     },
 
     overlayZoteroPane: function(doc) {
-        ZutiloChrome.zoteroOverlay.zoteroActionsMenu(doc);
-        ZutiloChrome.zoteroOverlay.zoteroMenu(doc);
-        ZutiloChrome.zoteroOverlay.zoteroItemPopup(doc);
+        var prefsId
+        if (Zotero.version.split('.')[0] < 5) {
+            prefsId = 'zotero-tb-actions-prefs'
+        } else {
+            prefsId = 'menu_preferences'
+        }
+        ZutiloChrome.zoteroOverlay.prefsMenuItem(doc, prefsId)
+        ZutiloChrome.zoteroOverlay.zoteroItemPopup(doc)
     },
 
     pageloadListener: function(event) {
@@ -717,58 +722,31 @@ ZutiloChrome.zoteroOverlay = {
         }
     },
 
-    zoteroActionsMenu: function(doc) {
-        // Add Zutilo preferences item to Zotero actions menu
-        var zoteroActionMenu = doc.getElementById('zotero-tb-actions-popup');
-        if (zoteroActionMenu === null) {
-            // Don't do anything if elements not loaded yet
-            return;
-        }
-
-        var zutiloMenuItem = doc.createElement('menuitem');
-        var zutiloMenuItemID = 'zutilo-zotero-actions-preferences';
-        zutiloMenuItem.setAttribute('id', zutiloMenuItemID);
-        zutiloMenuItem.setAttribute('label',
-            Zutilo._bundle.
-                GetStringFromName('zutilo.zotero.actions.preferences'));
-        zutiloMenuItem.addEventListener('command',
-            function() {
-                ZutiloChrome.openPreferences();
-            }, false);
-        var zoteroPrefsItem =
-            doc.getElementById('zotero-tb-actions-prefs');
-        zoteroActionMenu.insertBefore(zutiloMenuItem,
-                                      zoteroPrefsItem.nextSibling);
-
-        ZutiloChrome.registerXUL(zutiloMenuItemID, doc);
-    },
-	
-	zoteroMenu: function(doc) {
-        // Add Zutilo preferences item to Zotero actions menu
-		var zoteroPrefsMenu = doc.getElementById('menu_preferences').parentElement;
+    prefsMenuItem: function(doc, prefsId) {
+        // Add Zutilo preferences item after Zotero preferences menu item
+        var zoteroPrefsItem = doc.getElementById(prefsId)
+        var zoteroPrefsMenu = zoteroPrefsItem.parentElement
         if (zoteroPrefsMenu === null) {
             // Don't do anything if elements not loaded yet
             return;
         }
 
-        var zutiloMenuItem = doc.createElement('menuitem');
-        var zutiloMenuItemID = 'zutilo-zotero-actions-preferences';
-        zutiloMenuItem.setAttribute('id', zutiloMenuItemID);
+        var zutiloMenuItem = doc.createElement('menuitem')
+        var zutiloMenuItemID = 'zutilo-preferences'
+        zutiloMenuItem.setAttribute('id', zutiloMenuItemID)
         zutiloMenuItem.setAttribute('label',
             Zutilo._bundle.
-                GetStringFromName('zutilo.zotero.actions.preferences'));
+                GetStringFromName('zutilo.preferences.menuitem'))
         zutiloMenuItem.addEventListener('command',
             function() {
-                ZutiloChrome.openPreferences();
-            }, false);
-        var zoteroPrefsItem =
-            doc.getElementById('menu_preferences');
+                ZutiloChrome.openPreferences()
+            }, false)
         zoteroPrefsMenu.insertBefore(zutiloMenuItem,
-                                      zoteroPrefsItem.nextSibling);
+                                      zoteroPrefsItem.nextSibling)
 
-        ZutiloChrome.registerXUL(zutiloMenuItemID, doc);
+        ZutiloChrome.registerXUL(zutiloMenuItemID, doc)
     },
-	
+
     /******************************************/
     // Item menu functions
     /******************************************/

--- a/addon/chrome/locale/de/zutilo/zutilo.dtd
+++ b/addon/chrome/locale/de/zutilo/zutilo.dtd
@@ -1,7 +1,5 @@
 <!ENTITY zutilo.name			"Zutilo">
 
-<!ENTITY zutilo.zotero.actions.preferences	"Zutilo Einstellugen...">
-
 <!ENTITY zutilo.startup.upgradetitle	"Zutilo: Upgrademeldung">
 
 <!ENTITY zutilo.zoteronotactive.title "Zutilo: Zotero nicht aktiv!">

--- a/addon/chrome/locale/de/zutilo/zutilo.properties
+++ b/addon/chrome/locale/de/zutilo/zutilo.properties
@@ -1,6 +1,6 @@
 zutilo.startup.upgrademessage	=
 
-zutilo.zotero.actions.preferences = Zutilo Einstellungen...
+zutilo.preferences.menuitem = Zutilo Einstellungen...
 
 zutilo.error.pastetitle			= Zutilo: Zwischenablage Fehler
 zutilo.error.pastemessage		= Zutilo versucht, Text aus der Zwischenablage zu kopieren, aber es wurde kein gültiger Text gefunden.

--- a/addon/chrome/locale/en-US/zutilo/zutilo.dtd
+++ b/addon/chrome/locale/en-US/zutilo/zutilo.dtd
@@ -1,7 +1,5 @@
 <!ENTITY zutilo.name			"Zutilo">
 
-<!ENTITY zutilo.zotero.actions.preferences	"Zutilo Preferences...">
-
 <!ENTITY zutilo.startup.upgradetitle	"Zutilo: Upgrade message">
 
 <!ENTITY zutilo.zoteronotactive.title "Zutilo: Zotero not active!">

--- a/addon/chrome/locale/en-US/zutilo/zutilo.properties
+++ b/addon/chrome/locale/en-US/zutilo/zutilo.properties
@@ -1,6 +1,6 @@
 zutilo.startup.upgrademessage	=
 
-zutilo.zotero.actions.preferences = Zutilo Preferences...
+zutilo.preferences.menuitem = Zutilo Preferences...
 
 zutilo.error.pastetitle			= Zutilo: clipboard error
 zutilo.error.pastemessage		= Zutilo attempted to copy text from the clipboard, but no valid text was found.

--- a/addon/chrome/locale/es/zutilo/zutilo.dtd
+++ b/addon/chrome/locale/es/zutilo/zutilo.dtd
@@ -1,7 +1,5 @@
 <!ENTITY zutilo.name			"Zutilo">
 
-<!ENTITY zutilo.zotero.actions.preferences	"Preferencias de Zutilo…">
-
 <!ENTITY zutilo.startup.upgradetitle	"Zutilo: Mensaje de actualización">
 
 <!ENTITY zutilo.zoteronotactive.title "Zutilo: ¡Zotero inactivo!">

--- a/addon/chrome/locale/es/zutilo/zutilo.properties
+++ b/addon/chrome/locale/es/zutilo/zutilo.properties
@@ -1,6 +1,6 @@
 zutilo.startup.upgrademessage	=
 
-zutilo.zotero.actions.preferences = Preferencias de Zutilo…
+zutilo.preferences.menuitem = Preferencias de Zutilo…
 
 zutilo.error.pastetitle			= Zutilo: error de portapapeles
 zutilo.error.pastemessage		= Zutilo intentó duplicar texto desde el portapapeles, pero no encontró texto válido.

--- a/addon/chrome/locale/fr/zutilo/zutilo.dtd
+++ b/addon/chrome/locale/fr/zutilo/zutilo.dtd
@@ -1,7 +1,5 @@
 <!ENTITY zutilo.name			"Zutilo">
 
-<!ENTITY zutilo.zotero.actions.preferences	"Préférences de l'extension Zutilo">
-
 <!ENTITY zutilo.startup.upgradetitle	"Zutilo : message de mise à jour">
 
 <!ENTITY zutilo.zoteronotactive.title "Zutilo : Zotero n'est pas activé">

--- a/addon/chrome/locale/fr/zutilo/zutilo.properties
+++ b/addon/chrome/locale/fr/zutilo/zutilo.properties
@@ -1,6 +1,6 @@
 zutilo.startup.upgrademessage	=
 
-zutilo.zotero.actions.preferences = Préférences de Zutilo
+zutilo.preferences.menuitem = Préférences de Zutilo
 
 zutilo.error.pastetitle			= Zutilo : erreur avec le presse-papiers
 zutilo.error.pastemessage		= Zutilo a essayé de copier du texte depuis le presse-papiers, mais aucun texte valide n'a été trouvé.

--- a/addon/chrome/locale/zh-CN/zutilo/zutilo.dtd
+++ b/addon/chrome/locale/zh-CN/zutilo/zutilo.dtd
@@ -1,7 +1,5 @@
 <!ENTITY zutilo.name			"Zutilo">
 
-<!ENTITY zutilo.zotero.actions.preferences	"Zutilo 首选项...">
-
 <!ENTITY zutilo.startup.upgradetitle	"Zutilo：升级消息">
 
 <!ENTITY zutilo.zoteronotactive.title "Zutilo：Zotero 未激活！">

--- a/addon/chrome/locale/zh-CN/zutilo/zutilo.properties
+++ b/addon/chrome/locale/zh-CN/zutilo/zutilo.properties
@@ -1,6 +1,6 @@
 zutilo.startup.upgrademessage	=
 
-zutilo.zotero.actions.preferences = Zutilo 首选项...
+zutilo.preferences.menuitem = Zutilo 首选项...
 
 zutilo.error.pastetitle			= Zutilo：剪贴板错误
 zutilo.error.pastemessage		= Zutilo 尝试从剪贴板复制文本，但是未找到有效文本。

--- a/addon/install.rdf
+++ b/addon/install.rdf
@@ -5,7 +5,7 @@
 	<Description about="urn:mozilla:install-manifest">
 		<em:id>zutilo@www.wesailatdawn.com</em:id>
 		<em:name>Zutilo Utility for Zotero</em:name>
-		<em:version>2.0.2</em:version>
+		<em:version>2.0.3</em:version>
 		<em:multiprocessCompatible>true</em:multiprocessCompatible>
 		
 		<em:localized>


### PR DESCRIPTION
Because, in Zotero 5.0, "the Actions (gear icon) menu has been removed from the toolbar, as all options are now available in menus.
"Zutilo Preferences" is added after "Zotero Preferences" which is under "Edit" on Mac OS / Linux and under "Tools" on Windows.
See #61 