### PR TITLE
change `readlink -f` to `realpath`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INTERNAL_READMES := $(patsubst %, addon/chrome/locale/%/zutilo/README.html, $(LO
 AMO_READMES := $(patsubst %, $(BLDDIR)/amo_readme/%/README.html, $(LOCALES))
 
 # Necessary because zip copies leading directories if run from above targets
-ABS_BLDDIR := $(shell readlink -f $(BLDDIR))
+ABS_BLDDIR := $(shell realpath $(BLDDIR))
 
 all: xpi amo_readme
 


### PR DESCRIPTION
On linux `realpath` functions the same as `readlink -f`.
But on macOS, the build-in `readlink` doesn't have `-f` params, and the homebrew's coreutils adds the 'g' prefix to the conflict binaries. However, `realpath` is not a conflict binary.
