### PR TITLE
Zotero 8 migration updates

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -9,7 +9,6 @@
 const {classes: Cc, utils: Cu} = Components;
 var chromeHandle
 
-Cu.import("resource://gre/modules/Services.jsm");
 
 // eslint-disable-next-line no-unused-vars
 function install(data, reason) {
@@ -29,7 +28,7 @@ function startup(data, reason) {
         ["locale",  "zutilo", "zh-CN", "chrome/locale/zh-CN/zutilo/"]
     ])
 
-    Cu.import("chrome://zutilo/content/zutilo.js");
+    var { Zutilo } = ChromeUtils.importESModule("chrome://zutilo/content/zutilo.mjs");
     Zutilo.init(data.rootURI, Zotero);
 }
 
@@ -57,8 +56,6 @@ function shutdown(data, reason) {
 
     Cc["@mozilla.org/intl/stringbundle;1"].
         getService(Components.interfaces.nsIStringBundleService).flushBundles();
-
-    Cu.unload("chrome://zutilo/content/zutilo.js");
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/addon/chrome/content/zutilo/keys.js
+++ b/addon/chrome/content/zutilo/keys.js
@@ -11,8 +11,8 @@
 /********************************************/
 // Include core modules and built-in modules
 /********************************************/
-Components.utils.import('resource://gre/modules/AddonManager.jsm');
-Components.utils.import('chrome://zutilo/content/zutilo.js');
+var { AddonManager } = ChromeUtils.importESModule("resource://gre/modules/AddonManager.sys.mjs");
+var { Zutilo } = ChromeUtils.importESModule("chrome://zutilo/content/zutilo.mjs");
 
 /********************************************/
 // Define keys object
@@ -297,18 +297,18 @@ keys.categories.showFile = 'attachments'
 keys.shortcuts.showFile = function(win) {
     let zitems = win.ZoteroPane.getSelectedItems()
 
-    var _getBestFile = win.Zotero.Promise.coroutine(function* (item) {
+    var _getBestFile = (async function (item) {
         if(item.isAttachment()) {
             if(item.attachmentLinkMode === win.Zotero.Attachments.LINK_MODE_LINKED_URL) return false;
             return item;
         } else {
-            return yield item.getBestAttachment();
+            return await item.getBestAttachment();
         }
     });
 
-    win.Zotero.Promise.coroutine(function* (zitems){
+    (async function (zitems){
         for (let item of zitems) {
-            var attachment = yield _getBestFile(item);
+            var attachment = await _getBestFile(item);
             if(attachment) {
                 win.ZoteroPane_Local.showAttachmentInFilesystem(attachment.id);
             }

--- a/addon/chrome/content/zutilo/preferences.js
+++ b/addon/chrome/content/zutilo/preferences.js
@@ -6,15 +6,15 @@
 'use strict';
 /* global window, document, Components */
 /* global keyconfigOnLoad, Zutilo */
-Components.utils.import('chrome://zutilo/content/zutilo.js');
+var { Zutilo } = ChromeUtils.importESModule("chrome://zutilo/content/zutilo.mjs");
 
 // eslint-disable-next-line no-unused-vars
-function initializePrefWindow() {
+window.initializePrefWindow = function() {
     // keyconfigOnLoad();
 }
 
 // eslint-disable-next-line no-unused-vars
-function buildMenuPrefs() {
+window.buildMenuPrefs = function() {
     for (const menuName of ['item', 'collection']) {
         for (const functionName of Zutilo._menuFunctions[menuName]) {
             addMenuRadiogroup(menuName, functionName);
@@ -56,10 +56,4 @@ function addMenuRadiogroup(menuName, menuFunction) {
 
     var menuRows = document.getElementById(`zutilo-prefpane-${menuName}-rows`);
     menuRows.appendChild(newRow);
-}
-
-// eslint-disable-next-line no-unused-vars
-function showReadme() {
-    window.openDialog('chrome://zutilo/content/readme.xul',
-        'zutilo-readme-window', 'chrome');
 }

--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -7,8 +7,9 @@
 /* global window, document, Components */
 /* global Zotero, ZoteroPane, ZOTERO_CONFIG */
 /* global Zutilo, ZutiloChrome */
-Components.utils.import('chrome://zutilo/content/zutilo.js');
-Components.utils.import('resource://zotero/config.js');
+var { Zutilo } = ChromeUtils.importESModule("chrome://zutilo/content/zutilo.mjs");
+// Already declared in this context
+// var { ZOTERO_CONFIG } = ChromeUtils.importESModule("resource://zotero/config.mjs");
 
 function debug(msg, err) {
     if (err) {
@@ -57,10 +58,13 @@ ZutiloChrome.zoteroOverlay = {
         }
 
         // Select info tab of item pane
-        var tabIndex = 0;
-        var zoteroViewTabbox =
+        let tabIndex = 0;
+        let zoteroViewTabbox =
             ZoteroPane.document.getElementById('zotero-view-tabbox');
-        zoteroViewTabbox.selectedIndex = tabIndex;
+        // tabbox removed in Zotero 8 (just one big tab now)
+        if (zoteroViewTabbox !== undefined) {
+            zoteroViewTabbox.selectedIndex = tabIndex;
+        }
         // Focus first entry textbox of info pane
         ZoteroPane.document.getElementById('zotero-editpane-item-box').
             focusFirstField('info');
@@ -75,10 +79,13 @@ ZutiloChrome.zoteroOverlay = {
         }
 
         // Select note tab of item pane
-        var tabIndex = 1;
-        var zoteroViewTabbox =
+        let tabIndex = 1;
+        let zoteroViewTabbox =
             ZoteroPane.document.getElementById('zotero-view-tabbox');
-        zoteroViewTabbox.selectedIndex = tabIndex;
+        // tabbox removed in Zotero 8 (just one big tab now)
+        if (zoteroViewTabbox !== undefined) {
+            zoteroViewTabbox.selectedIndex = tabIndex;
+        }
         // Create new note
         ZoteroPane.newNote(false, zitems[0].key)
 
@@ -92,9 +99,12 @@ ZutiloChrome.zoteroOverlay = {
         }
 
         // Select tag tab of item pane
+        let tabbox = ZoteroPane.document.getElementById('zotero-view-tabbox')
         var tabIndex = 2
-        ZoteroPane.document.getElementById('zotero-view-tabbox').
+        // tabbox removed in Zotero 8 (just one big tab now)
+        if (tabbox !== undefined) {
             tabs.selectedIndex = tabIndex
+        }
         // Focus new tag entry textbox
         let header = ZoteroPane.document.querySelector(".tags-box-header")
         if (header === null) {
@@ -120,10 +130,13 @@ ZutiloChrome.zoteroOverlay = {
         }
 
         // Select related tab of item pane
-        var tabIndex = 3;
-        var zoteroViewTabbox =
+        let tabIndex = 3;
+        let zoteroViewTabbox =
             ZoteroPane.document.getElementById('zotero-view-tabbox');
-        zoteroViewTabbox.selectedIndex = tabIndex;
+        // tabbox removed in Zotero 8 (just one big tab now)
+        if (zoteroViewTabbox !== undefined) {
+            zoteroViewTabbox.selectedIndex = tabIndex;
+        }
         // Open add related window
         ZoteroPane.document.getElementById('zotero-editpane-related').add();
 
@@ -294,10 +307,13 @@ ZutiloChrome.zoteroOverlay = {
 
     CopyItems: new class {
         constructor() {
-            // this gets us a BlueBird promise which has isPending
-            this.ready = new Zotero.Promise((resolve, reject) => {
+            this.ready = false
+            this.ready_promise = new Promise((resolve, reject) => {
                 this._init()
-                    .then(() => resolve(true))
+                    .then(() => {
+                        resolve(true)
+                        this.ready = true
+                    })
                     .catch((err) => {
                         debug('CopyItems._init', err)
                         reject(err)
@@ -888,9 +904,9 @@ ZutiloChrome.zoteroOverlay = {
             bookItem.addRelatedItem(sectionItem);
             sectionItem.addRelatedItem(bookItem);
 
-            Zotero.Promise.coroutine(function*() {
-                yield sectionItem.saveTx()
-                yield bookItem.saveTx()
+            (async function() {
+                await sectionItem.saveTx()
+                await bookItem.saveTx()
 
                 // Update GUI and select textbox
                 context.editItemInfoGUI()
@@ -898,8 +914,8 @@ ZutiloChrome.zoteroOverlay = {
         }
 
         // Duplicate item and then do the work
-        Zotero.Promise.coroutine(function*(context) {
-            let sectionItem = yield ZoteroPane.duplicateSelectedItem()
+        (async function(context) {
+            let sectionItem = await ZoteroPane.duplicateSelectedItem()
             modifyNewItem(context, sectionItem)
         })(this)
 
@@ -941,9 +957,9 @@ ZutiloChrome.zoteroOverlay = {
             bookItem.addRelatedItem(sectionItem)
             sectionItem.addRelatedItem(bookItem)
 
-            Zotero.Promise.coroutine(function*() {
-                yield sectionItem.saveTx()
-                yield bookItem.saveTx()
+            (async function() {
+                await sectionItem.saveTx()
+                await bookItem.saveTx()
 
                 // Update GUI and select textbox
                 context.editItemInfoGUI()
@@ -951,8 +967,8 @@ ZutiloChrome.zoteroOverlay = {
         }
 
         // Duplicate item and then do the work
-        Zotero.Promise.coroutine(function*(context) {
-            let bookItem = yield ZoteroPane.duplicateSelectedItem()
+        (async function(context) {
+            let bookItem = await ZoteroPane.duplicateSelectedItem()
             modifyNewItem(context, bookItem)
         })(this)
 
@@ -1027,11 +1043,11 @@ ZutiloChrome.zoteroOverlay = {
 
     CheckVisibility: new class {
         copyJSON() {
-            return !ZutiloChrome.zoteroOverlay.CopyItems.ready.isPending() && ZutiloChrome.zoteroOverlay.CopyItems.sourceItem()
+            return ZutiloChrome.zoteroOverlay.CopyItems.ready && ZutiloChrome.zoteroOverlay.CopyItems.sourceItem()
         }
 
         pasteJSON() {
-            return !ZutiloChrome.zoteroOverlay.CopyItems.ready.isPending() && ZutiloChrome.zoteroOverlay.CopyItems.targetItems().length && ZutiloChrome.zoteroOverlay.CopyItems.clipboard()
+            return ZutiloChrome.zoteroOverlay.CopyItems.ready && ZutiloChrome.zoteroOverlay.CopyItems.targetItems().length && ZutiloChrome.zoteroOverlay.CopyItems.clipboard()
         }
 
         pasteJSONIntoEmptyFields() {

--- a/addon/chrome/content/zutilo/zutilo.mjs
+++ b/addon/chrome/content/zutilo/zutilo.mjs
@@ -5,16 +5,14 @@
 'use strict'
 /* global Components, Services */
 
-// eslint-disable-next-line no-unused-vars
-var EXPORTED_SYMBOLS = ['Zutilo'];
-
+ 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 var Zotero = null
 
 /**
  * Zutilo namespace.
  */
-var Zutilo = {
+export var Zutilo = {
     /********************************************/
     // Basic information
     /********************************************/

--- a/addon/chrome/content/zutilo/zutiloChrome.js
+++ b/addon/chrome/content/zutilo/zutiloChrome.js
@@ -11,8 +11,7 @@
 var Cc = Components.classes
 var Ci = Components.interfaces
 var Cu = Components.utils
-Cu.import('resource://gre/modules/AddonManager.jsm');
-Cu.import('chrome://zutilo/content/zutilo.js');
+var { Zutilo } = ChromeUtils.importESModule("chrome://zutilo/content/zutilo.mjs");
 
 /******************************************/
 // Initialization

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -12,8 +12,8 @@
     "zotero": {
       "id": "zutilo@www.wesailatdawn.com",
       "update_url": "https://raw.githubusercontent.com/wshanks/Zutilo/release/deploy/updates.json",
-      "strict_min_version": "7.0.0",
-      "strict_max_version": "7.*"
+      "strict_min_version": "8.0.0",
+      "strict_max_version": "8.*"
     }
   }
 }

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -15,7 +15,7 @@ The `make` machinery is mainly used for converting the README files from `markdo
 Most of the Zutilo logic is contained in the files in `addon/chrome/content/zutilo`.
 The highlights are:
 
-* `zutilo.js`
+* `zutilo.mjs`
   - `addon/bootstrap.js` loads this file when Zutilo starts up and it handles the rest of the Zutilo setup.
   - This file defines the `Zutilo` module.
   - The `Zutilo` module contains properties about Zutilo that are window independent.

--- a/i18n/de/readme/docs/DEVELOPERS.md
+++ b/i18n/de/readme/docs/DEVELOPERS.md
@@ -15,7 +15,7 @@ The `make` machinery is mainly used for converting the README files from `markdo
 Most of the Zutilo logic is contained in the files in `addon/chrome/content/zutilo`.
 The highlights are:
 
-* `zutilo.js`
+* `zutilo.mjs`
   - `addon/bootstrap.js` loads this file when Zutilo starts up and it handles the rest of the Zutilo setup.
   - This file defines the `Zutilo` module.
   - The `Zutilo` module contains properties about Zutilo that are window independent.

--- a/i18n/en-US/readme/docs/DEVELOPERS.md
+++ b/i18n/en-US/readme/docs/DEVELOPERS.md
@@ -15,7 +15,7 @@ The `make` machinery is mainly used for converting the README files from `markdo
 Most of the Zutilo logic is contained in the files in `addon/chrome/content/zutilo`.
 The highlights are:
 
-* `zutilo.js`
+* `zutilo.mjs`
   - `addon/bootstrap.js` loads this file when Zutilo starts up and it handles the rest of the Zutilo setup.
   - This file defines the `Zutilo` module.
   - The `Zutilo` module contains properties about Zutilo that are window independent.

--- a/i18n/es/readme/docs/DEVELOPERS.md
+++ b/i18n/es/readme/docs/DEVELOPERS.md
@@ -15,7 +15,7 @@ The `make` machinery is mainly used for converting the README files from `markdo
 Most of the Zutilo logic is contained in the files in `addon/chrome/content/zutilo`.
 The highlights are:
 
-* `zutilo.js`
+* `zutilo.mjs`
   - `addon/bootstrap.js` loads this file when Zutilo starts up and it handles the rest of the Zutilo setup.
   - This file defines the `Zutilo` module.
   - The `Zutilo` module contains properties about Zutilo that are window independent.

--- a/i18n/fr/readme/docs/DEVELOPERS.md
+++ b/i18n/fr/readme/docs/DEVELOPERS.md
@@ -15,7 +15,7 @@ The `make` machinery is mainly used for converting the README files from `markdo
 Most of the Zutilo logic is contained in the files in `addon/chrome/content/zutilo`.
 The highlights are:
 
-* `zutilo.js`
+* `zutilo.mjs`
   - `addon/bootstrap.js` loads this file when Zutilo starts up and it handles the rest of the Zutilo setup.
   - This file defines the `Zutilo` module.
   - The `Zutilo` module contains properties about Zutilo that are window independent.

--- a/i18n/zh-CN/readme/docs/DEVELOPERS.md
+++ b/i18n/zh-CN/readme/docs/DEVELOPERS.md
@@ -15,7 +15,7 @@ The `make` machinery is mainly used for converting the README files from `markdo
 Most of the Zutilo logic is contained in the files in `addon/chrome/content/zutilo`.
 The highlights are:
 
-* `zutilo.js`
+* `zutilo.mjs`
   - `addon/bootstrap.js` loads this file when Zutilo starts up and it handles the rest of the Zutilo setup.
   - This file defines the `Zutilo` module.
   - The `Zutilo` module contains properties about Zutilo that are window independent.


### PR DESCRIPTION
* Convert zutilo.js into an ES module
* Update import syntax for modules
* Drop imports of Services.jsm
* Increase maximum Zotero version
* Convert Bluebird promises to Javascript promises
* Add preferences functions to the window scope