### PR TITLE
Add support for Zotero 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 4.2.1:
+
+    + Mark compatible with Zotero 9
+
 * In version 4.2.0:
 
     + Add new "Copy PDF links" menu item

--- a/addon/install.rdf
+++ b/addon/install.rdf
@@ -5,7 +5,7 @@
     <Description about="urn:mozilla:install-manifest">
         <em:id>zutilo@www.wesailatdawn.com</em:id>
         <em:name>Zutilo Utility for Zotero</em:name>
-        <em:version>4.2.0</em:version>
+        <em:version>4.2.1</em:version>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>
         <em:updateURL>https://raw.githubusercontent.com/wshanks/Zutilo/release/deploy/update.rdf</em:updateURL>
 

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zutilo Utility for Zotero",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A utility adding assorted macros for Zotero",
   "author": "Will Shanks",
   "icons": {
@@ -13,7 +13,7 @@
       "id": "zutilo@www.wesailatdawn.com",
       "update_url": "https://raw.githubusercontent.com/wshanks/Zutilo/release/deploy/updates.json",
       "strict_min_version": "8.0.0",
-      "strict_max_version": "8.*"
+      "strict_max_version": "9.*"
     }
   }
 }

--- a/deploy/updates.json
+++ b/deploy/updates.json
@@ -51,6 +51,16 @@
               "strict_max_version": "8.*"
             }
           }
+        },
+        {
+          "version": "4.2.1",
+          "update_link": "https://github.com/wshanks/Zutilo/releases/download/v4.2.1/zutilo.xpi",
+          "applications": {
+            "zotero": {
+              "strict_min_version": "8.0.0",
+              "strict_max_version": "9.*"
+            }
+          }
         }
       ]
     }

--- a/i18n/de/readme/CHANGELOG.md
+++ b/i18n/de/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 4.2.1:
+
+    + Mark compatible with Zotero 9
+
 * In version 3.10.0:
 
     + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6

--- a/i18n/es/readme/CHANGELOG.md
+++ b/i18n/es/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 4.2.1:
+
+    + Mark compatible with Zotero 9
+
 * In version 3.10.0:
 
     + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6

--- a/i18n/fr/readme/CHANGELOG.md
+++ b/i18n/fr/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 4.2.1:
+
+    + Mark compatible with Zotero 9
+
 * In version 3.10.0:
 
     + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6

--- a/i18n/zh-CN/readme/CHANGELOG.md
+++ b/i18n/zh-CN/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 4.2.1:
+
+    + Mark compatible with Zotero 9
+
 * In version 3.10.0:
 
     + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6

--- a/scripts/update_non_english.py
+++ b/scripts/update_non_english.py
@@ -2,10 +2,9 @@
 '''Copy new, uncommitted strings from English to non-English locales in lieu of
 getting translations'''
 
+import os
 from glob import iglob
 from itertools import chain
-import os
-# NOTE: requires Python >= 3.5
 from subprocess import run, PIPE
 
 
@@ -45,7 +44,5 @@ def main():
                        doc.replace('en-US', '{locale}'))
     update_locales('addon/chrome/locale/en-US/zutilo/zutilo.properties',
                    'addon/chrome/locale/{locale}/zutilo/zutilo.properties')
-    update_locales('addon/chrome/locale/en-US/zutilo/zutilo.dtd',
-                   'addon/chrome/locale/{locale}/zutilo/zutilo.dtd')
 
 main()


### PR DESCRIPTION
Raise max Zotero version to 9 and bump Zutilo version to 4.2.1 for a new release.