### PR TITLE
fix: use truthy check for tabbox in GUI shortcut functions

### DIFF
--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -62,7 +62,7 @@ ZutiloChrome.zoteroOverlay = {
         let zoteroViewTabbox =
             ZoteroPane.document.getElementById('zotero-view-tabbox');
         // tabbox removed in Zotero 8 (just one big tab now)
-        if (zoteroViewTabbox !== undefined) {
+        if (zoteroViewTabbox) {
             zoteroViewTabbox.selectedIndex = tabIndex;
         }
         // Focus first entry textbox of info pane
@@ -83,7 +83,7 @@ ZutiloChrome.zoteroOverlay = {
         let zoteroViewTabbox =
             ZoteroPane.document.getElementById('zotero-view-tabbox');
         // tabbox removed in Zotero 8 (just one big tab now)
-        if (zoteroViewTabbox !== undefined) {
+        if (zoteroViewTabbox) {
             zoteroViewTabbox.selectedIndex = tabIndex;
         }
         // Create new note
@@ -102,7 +102,7 @@ ZutiloChrome.zoteroOverlay = {
         let tabbox = ZoteroPane.document.getElementById('zotero-view-tabbox')
         var tabIndex = 2
         // tabbox removed in Zotero 8 (just one big tab now)
-        if (tabbox !== undefined) {
+        if (tabbox) {
             tabs.selectedIndex = tabIndex
         }
         // Focus new tag entry textbox
@@ -134,7 +134,7 @@ ZutiloChrome.zoteroOverlay = {
         let zoteroViewTabbox =
             ZoteroPane.document.getElementById('zotero-view-tabbox');
         // tabbox removed in Zotero 8 (just one big tab now)
-        if (zoteroViewTabbox !== undefined) {
+        if (zoteroViewTabbox) {
             zoteroViewTabbox.selectedIndex = tabIndex;
         }
         // Open add related window


### PR DESCRIPTION
## Problem

The four GUI keyboard shortcut functions in `addon/chrome/content/zutilo/zoteroOverlay.js` — `editItemInfoGUI`, `addNoteGUI`, `addTagGUI`, and `addRelatedGUI` — silently crash on Zotero 8+.

Each calls:

```js
let zoteroViewTabbox =
    ZoteroPane.document.getElementById(`zotero-view-tabbox`);
// tabbox removed in Zotero 8 (just one big tab now)
if (zoteroViewTabbox !== undefined) {
    zoteroViewTabbox.selectedIndex = tabIndex;
}
```

The guard `!== undefined` is wrong: `getElementById` returns `null` (not `undefined`) when the element is absent, and the `zotero-view-tabbox` element was removed in Zotero 8 (the source comment already acknowledges this). Since `null !== undefined` is `true`, the guard passes and the function executes `null.selectedIndex = tabIndex`, throwing a `TypeError: zoteroViewTabbox is null`. The function dies there, before reaching its actual work — e.g. `addNoteGUI` never calls `ZoteroPane.newNote()`.

## Reproduction

On Zotero 8/9 + Zutilo 4.2.1, bind a key to `addNote` via the `extensions.zutilo.shortcut.addNote` preference (since the Shortcuts UI is broken on Zotero 7+ per #280 / #286, pref-based binding is the only path):

```json
{"modifiers":"control alt","key":"N","keycode":null}
```

Restart, select a regular item, press `Ctrl+Alt+N`. Nothing happens. No error dialog. The note is never created.

## Fix

Replace `!== undefined` with a truthy check at all four sites:

```diff
-        if (zoteroViewTabbox !== undefined) {
+        if (zoteroViewTabbox) {
```

```diff
-        if (tabbox !== undefined) {
+        if (tabbox) {
```

Four lines changed, no behavior change on Zotero ≤7 (where the tabbox exists and is truthy). On Zotero 8+ the guard correctly short-circuits and the function continues to its real work.

## Verification

Patched the installed 4.2.1 XPI locally and confirmed on Zotero 9: after restart, `Ctrl+Alt+N` creates a child note attached to the selected item. User-confirmed working.

## Scope

Minimum change. No refactors, no comment cleanup, no touching the unrelated `tabs` typo in `addTagGUI` (line 106 references an undefined `tabs` variable instead of `tabbox`, but that branch never executes on Zotero 8+ because the tabbox check short-circuits first — fixing it would be a separate concern).

## Related issues

- #280 — Shortcuts UI broken on Zotero 7+
- #286 — Same UI issue confirmed on Zotero 7.0.24

This bug is distinct from those (it's in the runtime, not the prefs UI), but they share a theme: keyboard shortcuts are essentially non-functional on Zotero 7+.